### PR TITLE
Use casatools on mac instead of python-casacore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "scikit-learn",
     "scipy",
     "albumentations",
-    "python-casacore"
+    "python-casacore; sys_platform != 'darwin'",
+    "casatools; sys_platform == 'darwin'",
 ]
 
 [project.scripts]

--- a/rfi_toolbox/scripts/generate_dataset.py
+++ b/rfi_toolbox/scripts/generate_dataset.py
@@ -6,6 +6,10 @@ from torch.utils.data import Dataset
 from sklearn.preprocessing import RobustScaler
 import logging
 from tqdm import tqdm
+
+from rfi_toolbox.core.simulator import RFISimulator
+
+
 try:
     import casacore.tables as ct  # Import here
     use_casacore = True

--- a/rfi_toolbox/scripts/generate_dataset.py
+++ b/rfi_toolbox/scripts/generate_dataset.py
@@ -6,7 +6,12 @@ from torch.utils.data import Dataset
 from sklearn.preprocessing import RobustScaler
 import logging
 from tqdm import tqdm
-import casacore.tables as ct  # Import here
+try:
+    import casacore.tables as ct  # Import here
+    use_casacore = True
+except ImportError:
+    from casatools import table
+    use_casacore = False
 
 class RFIMaskDataset(Dataset):
     def __init__(self, data_dir, transform=None, normalization='global_min_max', use_ms=False, ms_name=None, field_selection=None):
@@ -36,7 +41,11 @@ class RFIMaskDataset(Dataset):
         if use_ms:
             if not ms_name:
                 raise ValueError("ms_name must be provided when use_ms is True")
-            self.tb = ct.table(ms_name, readonly=True)
+            if use_casacore:
+                self.tb = ct.table(ms_name, readonly=True)
+            else:
+                tb = table()
+                self.tb = tb.open(ms_name, readonly=True)
             self.num_antennas = self.tb.getcol('ANTENNA1').max() + 1
             self.spw_array = np.unique(self.tb.getcol('DATA_DESC_ID'))
 

--- a/rfi_toolbox/scripts/generate_dataset.py
+++ b/rfi_toolbox/scripts/generate_dataset.py
@@ -10,8 +10,11 @@ try:
     import casacore.tables as ct  # Import here
     use_casacore = True
 except ImportError:
-    from casatools import table
-    use_casacore = False
+    try:
+        from casatools import table
+        use_casacore = False
+    except ImportError:
+        raise ImportError("Please install casacore or casatools to use this script.")
 
 class RFIMaskDataset(Dataset):
     def __init__(self, data_dir, transform=None, normalization='global_min_max', use_ms=False, ms_name=None, field_selection=None):


### PR DESCRIPTION
python-casacore has known issues when pip installing on a mac. Added a trap to pyproject.toml that installs casatools instead if it detects a Mac. 

Traps have also been put into generate_dataset to switch to casatools if python-casacore is not importable, and complain and quit if neither are present.